### PR TITLE
Update base Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- (docker) Optimized image quantization.
+
 ## [3.28.0] - 2025-03-31
 ### Added
 - Add [IMGPROXY_BASE64_URL_INCLUDES_FILENAME](https://docs.imgproxy.net/latest/configuration/options#IMGPROXY_BASE64_URL_INCLUDES_FILENAME) config.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE_VERSION="v3.13.0"
+ARG BASE_IMAGE_VERSION="v3.13.2"
 
 FROM ghcr.io/imgproxy/imgproxy-base:${BASE_IMAGE_VERSION} AS build
 


### PR DESCRIPTION
<!-- begin-generated-description -->

This PR updates the base image version and adds a new configuration option to the changelog.

- The base image version has been updated from v3.13.0 to v3.13.2.
- The changelog has been updated to include a new configuration option: IMGPROXY_BASE64_URL_INCLUDES_FILENAME.
- Image quantization has been optimized in the docker file.

<!-- end-generated-description -->